### PR TITLE
Install with pip

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -26,10 +26,10 @@ requirements:
     - simplegeneric >0.8
 # These are listed in the setup.py, but do not cause the build tests to fail.
 # In order to enable these dependencies, additional tests will need to be defined.
-#    - decorator
 #    - prompt_toolkit >=0.60 
 #    - pygments
 #    - shutil_get_terminal_size
+    - decorator
     - traitlets
     - pexpect              # [unix]
     - appnope              # [osx]

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -10,7 +10,7 @@ source:
   md5: 28c9ebd1abfb9b4a07cb87005f285edd
 
 build:
-  script: python setup.py install
+  script: python -m pip install --no-deps .
   number: 0
   entry_points:
     - ipython = IPython:start_ipython
@@ -20,6 +20,7 @@ build:
 requirements:
   build:
     - python
+    - pip
   run:
     - python
     - pickleshare


### PR DESCRIPTION
ensures setuptools metadata is defined, so downstream packages installed by pip can depend on `ipython[notebook]`, for instance.

decorator dependency is declared, as it really is needed. `python -c 'import IPython'` fails if decorator is missing.