### PR TITLE
Bump to 4.2

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -26,8 +26,9 @@ install:
 
       export PATH=/Users/travis/miniconda3/bin:$PATH
 
+      conda config --set show_channel_urls true
       conda update --yes conda
-      conda install --yes conda-build jinja2 anaconda-client
+      conda install --yes conda-build=1.20.0 jinja2 anaconda-client
       conda config --add channels conda-forge
       
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -14,14 +14,14 @@ env:
     - secure: "0YeCBr4vjFvq/SqkKKKm9FBZTZHBWuD+WUv5UJAlWmFtP0bsa0W50PG46rvlqBo5FVt9/DNOobGqEceyPQ6T/74bOYhxB/Hc99Fzt2pdjVDQmsAbcCf/h6kG6RZieAC0Fvw0MQ4NqTRhXYBq/TTH9Ux4x356plRG45gx/locACo51DzCG8PGC5LSJLe33bUWQrOH9JZjpNT/CnrjeM7aOYtIMNPnaLhaq0MGpHb+O6wteu1XHYwRuLHyF2r0Bq5GMr/A8WNnRih+bwIzNQFCd9ar1iE2HIIkkILn2JSAYVmZxfSZcYFyi0IuVa6qe+S2J9VRhn5n1e4x2ERISmHrY8tmQTmNz1hPAUztCZtJLuGIzFsW/EoXXCmlj4U2SLEqAaBgvWTMNESGt7dQ6B+jfk02kOdswHmBeciLX6TlYwWbL0weGHXaW+W+i9H7YfOshXYLGxoUADpIfzS+cZg4jIlpD75YIACfU9n+3b3mSuw3pgB6RdklI42c7WpWkMq9akxEJAumMMpXNYAL+IUXHm2fmaq5SWWr4O7Cz+rdqtX5O2yfMWkbaehIr+p60FjwGhPgMWm0H+aug6mnK6lNwCdZLiHSezEpS3SOiPawGna5MGOUHcj9Pcw0AX2grz03hvBaDryWpalUAq5YEvkILtg9Xi4qhwGlPRQhhLJF7xA="
 
 
-before install:
+before_install:
     - brew remove --force $(brew list)
 
 install:
     - |
       MINICONDA_URL="http://repo.continuum.io/miniconda"
       MINICONDA_FILE="Miniconda3-latest-MacOSX-x86_64.sh"
-      wget "${MINICONDA_URL}/${MINICONDA_FILE}"
+      curl -O "${MINICONDA_URL}/${MINICONDA_FILE}"
       bash $MINICONDA_FILE -b
 
       export PATH=/Users/travis/miniconda3/bin:$PATH

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ Home: http://ipython.org/
 
 Package license: BSD 3-clause
 
-Feedstock license: BSD
+Feedstock license: BSD 3-Clause
 
 Summary: IPython: Productive Interactive Computing
 

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -59,10 +59,15 @@ install:
     - cmd: set PATH=%CONDA_INSTALL_LOCN%;%CONDA_INSTALL_LOCN%\scripts;%PATH%
     - cmd: set PYTHONUNBUFFERED=1
 
+    - cmd: conda config --set show_channel_urls true
     - cmd: conda install -c http://conda.binstar.org/pelson/channel/development --yes --quiet obvious-ci
     - cmd: conda config --add channels http://conda.binstar.org/conda-forge
     - cmd: conda info
     - cmd: conda install -n root --quiet --yes conda-build anaconda-client jinja2 setuptools
+    # Workaround for Python 3.4 and x64 bug in latest conda-build.
+    # FIXME: Remove once there is a release that fixes the upstream issue
+    # ( https://github.com/conda/conda-build/issues/895 ).
+    - cmd: if "%TARGET_ARCH%" == "x64" if "%CONDA_PY%" == "34" conda install conda-build=1.20.0 --yes
 
 # Skip .NET project specific build phase.
 build: off

--- a/ci_support/run_docker_build.sh
+++ b/ci_support/run_docker_build.sh
@@ -20,7 +20,7 @@ channels:
 conda-build:
  root-dir: /feedstock_root/build_artefacts
 
-show_channel_urls: True
+show_channel_urls: true
 
 CONDARC
 )

--- a/recipe/bld.bat
+++ b/recipe/bld.bat
@@ -1,2 +1,0 @@
-python setup.py install
-if errorlevel 1 exit 1

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,4 +1,4 @@
-{% set version = "4.1.2" %}
+{% set version = "4.2.0" %}
 
 package:
   name: ipython
@@ -6,8 +6,8 @@ package:
 
 source:
   fn: ipython-{{ version }}.tar.gz
-  url: https://pypi.python.org/packages/source/i/ipython/ipython-{{ version }}.tar.gz
-  md5: 28c9ebd1abfb9b4a07cb87005f285edd
+  url: https://pypi.python.org/packages/4e/c7/519b95112dba6f3ae91530bcb8564454c575fcb1fdb323b2b0ee9eff1227/ipython-{{ version }}.tar.gz
+  md5: 9c7c28eddbc39eb874d2c22025772d63
 
 build:
   script: python -m pip install --no-deps .
@@ -27,7 +27,7 @@ requirements:
     - simplegeneric >0.8
 # These are listed in the setup.py, but do not cause the build tests to fail.
 # In order to enable these dependencies, additional tests will need to be defined.
-#    - prompt_toolkit >=0.60 
+#    - prompt_toolkit >=0.60
 #    - pygments
 #    - shutil_get_terminal_size
     - decorator
@@ -35,6 +35,7 @@ requirements:
     - pexpect              # [unix]
     - appnope              # [osx]
     - pyreadline           # [win]
+    - backports.shutil_get_terminal_size
 
 test:
   commands:


### PR DESCRIPTION
### IPython 4.2 (April, 2016) includes various bugfixes and improvements over 4.1.

- Fix ipython -i on errors, which was broken in 4.1.
- The delay meant to highlight deprecated commands that have moved to jupyter has been removed.
- Improve compatibility with future versions of traitlets and matplotlib.
- Use stdlib shutil.get_terminal_size() to measure terminal width when displaying tracebacks (provided by - backports.shutil_get_terminal_size on Python 2).

PS: Note that I was unable to build without `backports.shutil_get_terminal_size` on Python 3.5 too.