### PR TITLE
Release 5.4.1

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,4 +1,4 @@
-{% set version = "5.3.0" %}
+{% set version = "5.4.1" %}
 
 package:
   name: ipython
@@ -7,7 +7,7 @@ package:
 source:
   fn: ipython-{{ version }}.tar.gz
   url: https://pypi.io/packages/source/i/ipython/ipython-{{ version }}.tar.gz
-  sha256: bf5e615e7d96dac5a61fbf98d9e2926d98aa55582681bea7e9382992a3f43c1d
+  sha256: afaa92343c20cf4296728161521d84f606d8817f963beaf7198e63dfede897fb
 
 build:
   number: 0
@@ -45,7 +45,7 @@ test:
     - IPython
 
 about:
-  home: http://ipython.org/
+  home: https://ipython.org/
   license: BSD 3-clause
   license_file: COPYING.rst
   summary: "IPython: Productive Interactive Computing"


### PR DESCRIPTION
There is no 5.4 (well there is but it's partially broken as the
vendoring is backport.shutils-get-terminal-size was not done correctly so break
some stuf).

And we keep above mentioned package as a dependency as we try to import
it, but as backport packages are a mess, we fallback on a vendored
version if the import fail. SO no change to the recipe