### PR TITLE
fix link to LICENCE file

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -45,7 +45,7 @@ test:
 about:
   home: https://ipython.org/
   license: BSD 3-clause
-  license_file: COPYING.rst
+  license_file: LICENCE
   summary: "IPython: Productive Interactive Computing"
 
 extra:


### PR DESCRIPTION
Not a request to merge (we should fix that at next release), but is this something that conda-smithy should check ?