### PR TITLE
IPython 7.10.1

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,4 +1,4 @@
-{% set version = "7.10.0" %}
+{% set version = "7.10.1" %}
 
 package:
   name: ipython
@@ -6,7 +6,7 @@ package:
 
 source:
   url: https://pypi.io/packages/source/i/ipython/ipython-{{ version }}.tar.gz
-  sha256: e468b8f03a0168a667982b50f0b4e0828cc32721bbea32b23934e55b7970eb7a
+  sha256: f186b01b36609e0c5d0de27c7ef8e80c990c70478f8c880863004b3489a9030e
 
 build:
   number: 0
@@ -30,7 +30,7 @@ requirements:
     - jedi >=0.10
     - pexpect  # [unix]
     - pickleshare
-    - prompt_toolkit >=2.0.0,<4
+    - prompt_toolkit >=2.0.0,<4,!=3.0.0,!=3.0.1
     - pygments
     - python
     - traitlets >=4.2


### PR DESCRIPTION
Done manually to exclude prompt toolkit 3.0.0 and 3.0.1 as we use API
only available in 3.0.2

Checklist
* [x] Used a [fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
* [x] Reset the build number to `0` (if the version changed)
* [x] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [x] Ensured the license file is being packaged.