### PR TITLE
Typo on prompt_toolkit

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -30,7 +30,7 @@ requirements:
     - jedi >=0.10
     - pexpect  # [unix]
     - pickleshare
-    - prompt-toolkit !=3.0.0,!=3.0.1,<3.1.0,>=2.0.0
+    - prompt_toolkit !=3.0.0,!=3.0.1,<3.1.0,>=2.0.0
     - pygments
     - python
     - traitlets >=4.2


### PR DESCRIPTION
Hi,

There is a huge issue on the last ipython conda release 7.15.0.

There is a typo on prompt-toolkit, unfortunately both package exists:
- https://anaconda.org/conda-forge/prompt_toolkit/files
- https://anaconda.org/conda-forge/prompt-toolkit/files

 As you can see the second one only contains few files.

As result constraints dependency became nightmare on other projects, cause most of them deal with `prompt_toolkit` and ipython deal with `prompt-toolkit`.

Is that typo the problem? or that's something else? 

<!--
Thank you for pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [ ] Used a [fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [ ] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [ ] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [ ] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
