### PR TITLE
temporary pin for jedi<0.18

### DIFF
--- a/.ci_support/osx_arm64_python3.8.____cpython.yaml
+++ b/.ci_support/osx_arm64_python3.8.____cpython.yaml
@@ -1,7 +1,7 @@
 MACOSX_DEPLOYMENT_TARGET:
 - '11.0'
 channel_sources:
-- conda-forge/label/rust_dev,conda-forge,https://conda-web.anaconda.org/conda-forge
+- conda-forge
 channel_targets:
 - conda-forge main
 macos_machine:

--- a/.ci_support/osx_arm64_python3.9.____cpython.yaml
+++ b/.ci_support/osx_arm64_python3.9.____cpython.yaml
@@ -1,7 +1,7 @@
 MACOSX_DEPLOYMENT_TARGET:
 - '11.0'
 channel_sources:
-- conda-forge/label/rust_dev,conda-forge,https://conda-web.anaconda.org/conda-forge
+- conda-forge
 channel_targets:
 - conda-forge main
 macos_machine:

--- a/.scripts/run_docker_build.sh
+++ b/.scripts/run_docker_build.sh
@@ -45,8 +45,12 @@ fi
 if [ -z "${DOCKER_IMAGE}" ]; then
     SHYAML_INSTALLED="$(shyaml -h || echo NO)"
     if [ "${SHYAML_INSTALLED}" == "NO" ]; then
-        echo "WARNING: DOCKER_IMAGE variable not set and shyaml not installed. Falling back to condaforge/linux-anvil-comp7"
-        DOCKER_IMAGE="condaforge/linux-anvil-comp7"
+        echo "WARNING: DOCKER_IMAGE variable not set and shyaml not installed. Trying to parse with coreutils"
+        DOCKER_IMAGE=$(cat .ci_support/${CONFIG}.yaml | grep '^docker_image:$' -A 1 | tail -n 1 | cut -b 3-)
+        if [ "${DOCKER_IMAGE}" = "" ]; then
+            echo "No docker_image entry found in ${CONFIG}. Falling back to condaforge/linux-anvil-comp7"
+            DOCKER_IMAGE="condaforge/linux-anvil-comp7"
+        fi
     else
         DOCKER_IMAGE="$(cat "${FEEDSTOCK_ROOT}/.ci_support/${CONFIG}.yaml" | shyaml get-value docker_image.0 condaforge/linux-anvil-comp7 )"
     fi
@@ -64,8 +68,8 @@ fi
 
 export UPLOAD_PACKAGES="${UPLOAD_PACKAGES:-True}"
 docker run ${DOCKER_RUN_ARGS} \
-           -v "${RECIPE_ROOT}":/home/conda/recipe_root:rw,z \
-           -v "${FEEDSTOCK_ROOT}":/home/conda/feedstock_root:rw,z \
+           -v "${RECIPE_ROOT}":/home/conda/recipe_root:rw,z,delegated \
+           -v "${FEEDSTOCK_ROOT}":/home/conda/feedstock_root:rw,z,delegated \
            -e CONFIG \
            -e HOST_USER_ID \
            -e UPLOAD_PACKAGES \

--- a/conda-forge.yml
+++ b/conda-forge.yml
@@ -2,3 +2,6 @@ build_platform: {osx_arm64: osx_64}
 conda_forge_output_validation: true
 provider: {linux_aarch64: default, linux_ppc64le: default, win: azure}
 test_on_native_only: true
+bot:
+  abi_migration_branches:
+   - "7.16.x"

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -9,8 +9,8 @@ source:
   sha256: cbb2ef3d5961d44e6a963b9817d4ea4e1fa2eb589c371a470fed14d8d40cbd6a
 
 build:
-  number: 0
-  script: {{ PYTHON }} -m pip install . -vv
+  number: 1
+  script: {{ PYTHON }} -m pip install . -vv --no-deps
   skip: true  # [py<37]
   entry_points:
     - ipython = IPython:start_ipython
@@ -30,7 +30,8 @@ requirements:
     - backcall
     - colorama  # [win]
     - decorator
-    - jedi >=0.10
+    # TODO: unpin once fixed
+    - jedi >=0.10,<0.18
     - pexpect >4.3  # [unix]
     - pickleshare
     - prompt-toolkit !=3.0.0,!=3.0.1,<3.1.0,>=2.0.0


### PR DESCRIPTION
Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [x] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [x] Ensured the license file is being packaged.

- Adds a pin for jedi compatibility. 
- Will probably also do one for the 3.6 compatible line (7.16) as well...
  - #119 with backports for this PR and the OSX ARM migration
    - added new long-lived branch to `abi_migration_branches`