### PR TITLE
Fix ipython crash with python 3.9 on osx-arm64

### DIFF
--- a/recipe/fix-osx-py39-crash-gh12807.patch
+++ b/recipe/fix-osx-py39-crash-gh12807.patch
@@ -1,0 +1,11 @@
+--- a/IPython/terminal/pt_inputhooks/osx.py
++++ b/IPython/terminal/pt_inputhooks/osx.py
+@@ -41,7 +41,7 @@ def C(classname):
+ 
+ CFFileDescriptorCreate = CoreFoundation.CFFileDescriptorCreate
+ CFFileDescriptorCreate.restype = void_p
+-CFFileDescriptorCreate.argtypes = [void_p, ctypes.c_int, ctypes.c_bool, void_p]
++CFFileDescriptorCreate.argtypes = [void_p, ctypes.c_int, ctypes.c_bool, void_p, void_p]
+ 
+ CFFileDescriptorGetNativeDescriptor = CoreFoundation.CFFileDescriptorGetNativeDescriptor
+ CFFileDescriptorGetNativeDescriptor.restype = ctypes.c_int

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -8,11 +8,14 @@ source:
   url: https://pypi.io/packages/source/i/ipython/ipython-{{ version }}.tar.gz
   sha256: 1923af00820a8cf58e91d56b89efc59780a6e81363b94464a0f17c039dffff9e
   patches:
-    # Patch for osx crashes from https://github.com/ipython/ipython/pull/12804
+    # Patches for osx crashes from https://github.com/ipython/ipython/pull/12804
+    # and https://github.com/ipython/ipython/pull/12807
+    # These will be unnecessary when 7.21 arrives
     - fix-osx-crash-gh12804.patch  # [osx]
+    - fix-osx-py39-crash-gh12807.patch  # [osx]
 
 build:
-  number: 1
+  number: 2
   script: {{ PYTHON }} -m pip install . -vv --no-deps
   skip: true  # [py<37]
   entry_points:


### PR DESCRIPTION
<!--
Thank you for pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [ ] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [ ] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [ ] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [ ] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

This is a backport of https://github.com/ipython/ipython/pull/12807 .  Apologies to @bollwyvl for providing an incomplete fix in #129 that was incomplete for python 3.9.

<!--
Please add any other relevant info below:
-->
