### PR TITLE
fix missing deduperreload init file

### DIFF
--- a/recipe/recipe.yaml
+++ b/recipe/recipe.yaml
@@ -13,7 +13,7 @@ source:
   sha256: 9368d65b3d4a471e9a698fed3ea486bbf6737e45111e915279c971b77f974397
 
 build:
-  number: 0
+  number: 1
   noarch: python
 
 outputs:
@@ -22,6 +22,8 @@ outputs:
     build:
       noarch: python
       script:
+        # TODO: fix upstream
+        - ${{ PYTHON }} -c "from pathlib import Path; Path('IPython/extensions/deduperreload/__init__.py').touch()"
         - ${{ PYTHON }} -m pip install . -vv --no-deps --no-build-isolation --disable-pip-version-check
       python:
         entry_points:

--- a/recipe/run_test.py
+++ b/recipe/run_test.py
@@ -6,15 +6,13 @@ import sys
 WIN = platform.system() == "Windows"
 LINUX = platform.system() == "Linux"
 
-COV_THRESHOLD = 58
+COV_THRESHOLD = 57
 PYTEST_SKIPS = [
     "decorator_skip",
     "pprint_heap_allocated",
 ]
-UNLINK = [
-    # https://github.com/conda-forge/ipython-feedstock/pull/231
-    "test_zzz_autoreload.py",
-]
+UNLINK = []
+
 if LINUX:
     PYTEST_SKIPS += ["system_interrupt"]
 


### PR DESCRIPTION
Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [ ] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [ ] Ensured the license file is being packaged.

Changes:
- [x] adds missing `deduperreload/__init__.py`
- [x] remove test skip
- [x] adjust coverage

Follow-on:
- [ ] get `9.0.0_0` marked broken
  - [ ] > TBD